### PR TITLE
Restrict Mentors and Students from Clicking Future Dates #57

### DIFF
--- a/server/src/components/calendar.tsx
+++ b/server/src/components/calendar.tsx
@@ -242,18 +242,32 @@ const TaskCalendar: React.FC<TaskCalendarProps> = ({ selectedUser }) => {
   };
 
   const handleDateClick = (date: Date) => {
+    // Prevent clicking on future dates
+    const today = new Date();
+    today.setHours(0, 0, 0, 0); 
+    const clickedDate = new Date(date);
+    clickedDate.setHours(0, 0, 0, 0);
+    
+    // If the clicked date is in the future, don't allow selection
+    if (clickedDate > today) {
+      return; // Prevent further actions if the date is in the future
+    }
+    // End of prevent clicking on future dates
     setSelectedDate(date);
     const formattedDate = moment(date).format("YYYY-MM-DD");
-
-    const today = moment().startOf("day");
+  
+    const todayMoment = moment().startOf("day");
     const dayBeforeYesterday = moment().subtract(2, "days").startOf("day");
-
-    if (moment(date).isSame(today, 'day') || moment(date).isBetween(dayBeforeYesterday, today, 'day', '[]')) {
+  
+    if (
+      moment(date).isSame(todayMoment, "day") ||
+      moment(date).isBetween(dayBeforeYesterday, todayMoment, "day", "[]")
+    ) {
       setIsEditable(true);
     } else {
       setIsEditable(false);
     }
-
+  
     fetchEventForDate(formattedDate);
     setTaskModalOpen(true);
   };
@@ -269,7 +283,7 @@ const TaskCalendar: React.FC<TaskCalendarProps> = ({ selectedUser }) => {
     } else if (status === "rejected") {
       handleSubmit();
     }
-  }, [status]);
+  }, [status]);        
 
   /* 
 


### PR DESCRIPTION
Issue
Mentors and students were able to click on future dates, which incorrectly opened the "Mentor Task Details" and  "Student Task Details" windows. This behavior was unintended and needed to be restricted.

Fix
Implemented a check in handleDateClick to prevent interaction with future dates.
If a mentor or student clicks on a future date, the function stops execution, preventing unintended actions.
The date comparison ensures only past and present dates are selectable.